### PR TITLE
feat: add support to multiple dn

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ first class. For group membership you need both, since the
   cache key, but pass it through a hashing function first.
 
 ## Configuration
-  
+
 Configuration is done using Kafka properties: Either
 `dot.separated.properties`, or `KAFKA_ENVIRONMENT_VARIABLES`. To use
 environment variables, capitalize every letter of the original
@@ -89,7 +89,8 @@ directory expects as part of a bind operation. The `%s` combination
 will be replaced by a properly escaped version of what the user
 provided. On Active Directory this string should often be specified as
 just `%s`, since the directory authenticates using just the username
-without matching a full DN.
+without matching a full DN. If multiple DNs are used, they should be
+separated by semicolons.
 
 ### Group authorizer configuration
 

--- a/src/main/java/io/statnett/k3a/authz/ldap/LdapUsernamePasswordAuthenticator.java
+++ b/src/main/java/io/statnett/k3a/authz/ldap/LdapUsernamePasswordAuthenticator.java
@@ -60,7 +60,6 @@ implements UsernamePasswordAuthenticator {
     }
 
     private boolean authenticateByDn(final String userDn, final char[] password, final String originalUsername) {
-        // Split the userDn by semicolon and trim each DN
         String[] dns = userDn.split(";");
         for (String dn : dns) {
             String trimmedDn = dn.trim();

--- a/src/test/java/io/statnett/k3a/authz/ldap/LdapUsernamePasswordAuthenticatorIntegrationTest.java
+++ b/src/test/java/io/statnett/k3a/authz/ldap/LdapUsernamePasswordAuthenticatorIntegrationTest.java
@@ -24,8 +24,8 @@ public final class LdapUsernamePasswordAuthenticatorIntegrationTest {
     }
 
     @Test
-    public void shouldAcceptValidUsernameAndPassword() {
-        final LdapUsernamePasswordAuthenticator authenticator = getAuthenticator();
+    public void shouldAcceptValidUsernameAndPasswordWithMultipleDn() {
+        final LdapUsernamePasswordAuthenticator authenticator = getAuthenticatorWithMultipleDn();
         assertTrue(authenticator.authenticate(EmbeddedLdapUtils.EXISTING_USERNAME, EmbeddedLdapUtils.EXISTING_USER_PASSWORD));
     }
 
@@ -59,6 +59,10 @@ public final class LdapUsernamePasswordAuthenticatorIntegrationTest {
 
     private LdapUsernamePasswordAuthenticator getAuthenticator() {
         return new LdapUsernamePasswordAuthenticator(EmbeddedLdapUtils.getLdapConnectionSpec(LDAP_RULE), EmbeddedLdapUtils.USERNAME_TO_DN_FORMAT, EmbeddedLdapUtils.USERNAME_TO_UNIQUE_SEARCH_FORMAT, null, null);
+    }
+
+    private LdapUsernamePasswordAuthenticator getAuthenticatorWithMultipleDn() {
+        return new LdapUsernamePasswordAuthenticator(EmbeddedLdapUtils.getLdapConnectionSpec(LDAP_RULE), "cn=%s,dn=dont,dn=work;" + EmbeddedLdapUtils.USERNAME_TO_DN_FORMAT, EmbeddedLdapUtils.USERNAME_TO_UNIQUE_SEARCH_FORMAT, null, null);
     }
 
     private LdapUsernamePasswordAuthenticator getAuthenticatorWithServiceUser() {


### PR DESCRIPTION
By adding support to semi-colon separated userToDnFormats, more directory branches can be targeted for one username.